### PR TITLE
Translate user-facing text to English

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -29,7 +29,7 @@ class AuthController extends Controller
         $token = $user->createToken('auth_token')->plainTextToken;
 
         return response()->json([
-            'message' => 'Registro exitoso',
+            'message' => 'Registration successful',
             'user' => $user,
             'token' => $token,
         ], 201);
@@ -58,7 +58,7 @@ class AuthController extends Controller
         $token = $user->createToken('auth_token')->plainTextToken;
 
         return response()->json([
-            'message' => 'Registro exitoso',
+            'message' => 'Registration successful',
             'user' => $user,
             'token' => $token,
         ], 201);
@@ -73,7 +73,7 @@ class AuthController extends Controller
 
         if (!$user || !Hash::check($request->password, $user->password)) {
             throw ValidationException::withMessages([
-                'email' => ['Las credenciales proporcionadas son incorrectas.'],
+                'email' => ['The provided credentials are incorrect.'],
             ]);
         }
 
@@ -83,7 +83,7 @@ class AuthController extends Controller
         $token = $user->createToken('auth_token')->plainTextToken;
 
         return response()->json([
-            'message' => 'Inicio de sesión exitoso',
+            'message' => 'Login successful',
             'user' => $user,
             'token' => $token,
         ]);
@@ -97,7 +97,7 @@ class AuthController extends Controller
         $request->user()->currentAccessToken()->delete();
 
         return response()->json([
-            'message' => 'Sesión cerrada correctamente',
+            'message' => 'Logged out successfully',
         ]);
     }
 

--- a/app/Http/Controllers/DirectoryController.php
+++ b/app/Http/Controllers/DirectoryController.php
@@ -232,7 +232,7 @@ class DirectoryController extends Controller
     public function toggleFavorite(Request $request, $id)
     {
         if (!auth()->check()) {
-            return response()->json(['message' => 'Debes iniciar sesión para marcar favoritos'], 401);
+            return response()->json(['message' => 'You must be logged in to mark favorites'], 401);
         }
         
         $user = auth()->user();
@@ -244,12 +244,12 @@ class DirectoryController extends Controller
         if ($favorite) {
             // Si ya existe, lo eliminamos
             $user->favoriteDentists()->detach($id);
-            $message = 'Dentista eliminado de favoritos';
+            $message = 'Dentist removed from favorites';
             $isFavorite = false;
         } else {
             // Si no existe, lo agregamos
             $user->favoriteDentists()->attach($id);
-            $message = 'Dentista agregado a favoritos';
+            $message = 'Dentist added to favorites';
             $isFavorite = true;
         }
         
@@ -268,7 +268,7 @@ class DirectoryController extends Controller
     public function getFavorites(Request $request)
     {
         if (!auth()->check()) {
-            return response()->json(['message' => 'Debes iniciar sesión para ver favoritos'], 401);
+            return response()->json(['message' => 'You must be logged in to view favorites'], 401);
         }
         
         $user = auth()->user();

--- a/app/Http/Controllers/Installer/InstallerController.php
+++ b/app/Http/Controllers/Installer/InstallerController.php
@@ -97,7 +97,7 @@ class InstallerController extends Controller
 
             return redirect()->route('installer.complete');
         } catch (Exception $e) {
-            return back()->withInput()->withErrors(['error' => 'Error de instalación: ' . $e->getMessage()]);
+            return back()->withInput()->withErrors(['error' => 'Installation error: ' . $e->getMessage()]);
         }
     }
 
@@ -155,7 +155,7 @@ class InstallerController extends Controller
             
             return true;
         } catch (PDOException $e) {
-            throw new Exception('No se pudo conectar a la base de datos: ' . $e->getMessage());
+            throw new Exception('Could not connect to the database: ' . $e->getMessage());
         }
     }
 
@@ -220,7 +220,7 @@ class InstallerController extends Controller
             
             return true;
         } catch (Exception $e) {
-            throw new Exception('Error ejecutando migraciones: ' . $e->getMessage());
+            throw new Exception('Error running migrations: ' . $e->getMessage());
         }
     }
 
@@ -240,7 +240,7 @@ class InstallerController extends Controller
             
             return $user;
         } catch (Exception $e) {
-            throw new Exception('Error creando usuario administrador: ' . $e->getMessage());
+            throw new Exception('Error creating admin user: ' . $e->getMessage());
         }
     }
 
@@ -250,7 +250,7 @@ class InstallerController extends Controller
     private function setAsInstalled()
     {
         // Crear archivo que indica que la aplicación está instalada
-        File::put(storage_path('installed'), 'Instalación completada el ' . date('Y-m-d H:i:s'));
+        File::put(storage_path('installed'), 'Installation completed on ' . date('Y-m-d H:i:s'));
         
         // Optimizar la aplicación
         Artisan::call('optimize:clear');

--- a/resources/views/emails/dentist-verification-status.blade.php
+++ b/resources/views/emails/dentist-verification-status.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Actualización de Estado de Verificación</title>
+    <title>Verification Status Update</title>
     <style>
         body {
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
@@ -54,44 +54,44 @@
 </head>
 <body>
     <div class="header">
-        <h1>Comunidad Odontológica</h1>
+        <h1>Dental Community</h1>
     </div>
     <div class="content">
-        <p>Hola {{ $name }},</p>
+        <p>Hello {{ $name }},</p>
         
-        <p>Queremos informarte que el estado de verificación de tu perfil profesional ha sido actualizado.</p>
+        <p>We would like to inform you that the verification status of your professional profile has been updated.</p>
         
-        <p>El estado actual de tu perfil es: 
+        <p>The current status of your profile is:
             @if($status == 'approved')
-                <span class="status-approved">APROBADO</span>
+                <span class="status-approved">APPROVED</span>
             @elseif($status == 'rejected')
-                <span class="status-rejected">RECHAZADO</span>
+                <span class="status-rejected">REJECTED</span>
             @else
-                <span class="status-pending">PENDIENTE</span>
+                <span class="status-pending">PENDING</span>
             @endif
         </p>
 
         @if($notes)
             <div class="notes">
-                <h3>Notas del equipo de verificación:</h3>
+                <h3>Notes from the verification team:</h3>
                 <p>{{ $notes }}</p>
             </div>
         @endif
 
         @if($status == 'approved')
-            <p>¡Felicidades! Tu perfil es ahora visible en nuestra comunidad. Los pacientes podrán encontrar tu información profesional y contactarte a través de la plataforma.</p>
+            <p>Congratulations! Your profile is now visible in our community. Patients will be able to find your professional information and contact you through the platform.</p>
         @elseif($status == 'rejected')
-            <p>Por favor, revisa las notas proporcionadas por nuestro equipo de verificación y realiza las correcciones necesarias. Una vez actualizadas, tu perfil volverá a entrar en proceso de revisión.</p>
+            <p>Please review the notes provided by our verification team and make the necessary corrections. Once updated, your profile will be reviewed again.</p>
         @else
-            <p>Tu perfil está siendo revisado por nuestro equipo de verificación. Te notificaremos cuando haya novedades.</p>
+            <p>Your profile is being reviewed by our verification team. We will notify you when there are updates.</p>
         @endif
 
-        <p>Para ver más detalles o realizar cambios, inicia sesión en tu cuenta y visita la sección "Mi Perfil Profesional".</p>
+        <p>To see more details or make changes, log in to your account and visit the "My Professional Profile" section.</p>
         
-        <p>¡Gracias por formar parte de nuestra comunidad!</p>
+        <p>Thank you for being part of our community!</p>
     </div>
     <div class="footer">
-        <p>© {{ date('Y') }} Comunidad Odontológica - Todos los derechos reservados</p>
+        <p>© {{ date('Y') }} Dental Community - All rights reserved</p>
     </div>
 </body>
 </html>

--- a/resources/views/installer/complete.blade.php
+++ b/resources/views/installer/complete.blade.php
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Instalador - Instalación Completada - Comunidad Odontológica</title>
+    <title>Installer - Installation Complete - Dental Community</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
 </head>
 <body class="bg-gray-50">
     <div class="min-h-screen flex flex-col justify-center py-12">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="text-center mb-12">
-                <h1 class="text-4xl font-extrabold text-blue-800 tracking-tight">Comunidad Odontológica</h1>
-                <p class="mt-3 text-xl text-gray-600">Instalación Completada</p>
+                <h1 class="text-4xl font-extrabold text-blue-800 tracking-tight">Dental Community</h1>
+                <p class="mt-3 text-xl text-gray-600">Installation Complete</p>
             </div>
 
             <div class="bg-white shadow rounded-lg">
@@ -23,8 +23,8 @@
                             </svg>
                         </div>
                         <div class="ml-4">
-                            <h2 class="text-2xl font-semibold text-gray-800">¡Felicidades!</h2>
-                            <p class="mt-1 text-gray-600">La plataforma Comunidad Odontológica se ha instalado correctamente.</p>
+                            <h2 class="text-2xl font-semibold text-gray-800">Congratulations!</h2>
+                            <p class="mt-1 text-gray-600">The Dental Community platform has been installed successfully.</p>
                         </div>
                     </div>
                 </div>
@@ -38,15 +38,15 @@
                                 </svg>
                             </div>
                             <div class="ml-3">
-                                <h3 class="text-sm font-medium text-blue-800">Información importante</h3>
+                                <h3 class="text-sm font-medium text-blue-800">Important information</h3>
                                 <div class="mt-2 text-sm text-blue-700">
-                                    <p>Por razones de seguridad, debes eliminar la carpeta "installer" o deshabilitar el acceso al instalador.</p>
+                                    <p>For security reasons, you should remove the "installer" folder or disable access to it.</p>
                                 </div>
                             </div>
                         </div>
                     </div>
 
-                    <h3 class="text-lg font-medium text-gray-900">Próximos pasos</h3>
+                    <h3 class="text-lg font-medium text-gray-900">Next steps</h3>
 
                     <ul class="space-y-3">
                         <li class="flex items-start">
@@ -56,8 +56,8 @@
                                 </svg>
                             </div>
                             <div class="ml-3">
-                                <h4 class="text-base font-medium text-gray-800">Iniciar sesión como administrador</h4>
-                                <p class="mt-1 text-sm text-gray-600">Utiliza las credenciales que ingresaste durante la instalación para acceder al panel de administración.</p>
+                                <h4 class="text-base font-medium text-gray-800">Log in as administrator</h4>
+                                <p class="mt-1 text-sm text-gray-600">Use the credentials you entered during installation to access the admin panel.</p>
                             </div>
                         </li>
                         <li class="flex items-start">
@@ -67,8 +67,8 @@
                                 </svg>
                             </div>
                             <div class="ml-3">
-                                <h4 class="text-base font-medium text-gray-800">Personalizar la plataforma</h4>
-                                <p class="mt-1 text-sm text-gray-600">Configura los ajustes específicos para tu comunidad odontológica desde el panel de administración.</p>
+                                <h4 class="text-base font-medium text-gray-800">Customize the platform</h4>
+                                <p class="mt-1 text-sm text-gray-600">Configure the specific settings for your dental community from the admin panel.</p>
                             </div>
                         </li>
                         <li class="flex items-start">
@@ -78,8 +78,8 @@
                                 </svg>
                             </div>
                             <div class="ml-3">
-                                <h4 class="text-base font-medium text-gray-800">Invitar a usuarios</h4>
-                                <p class="mt-1 text-sm text-gray-600">Comienza a crecer tu comunidad invitando a colegas profesionales de la odontología.</p>
+                                <h4 class="text-base font-medium text-gray-800">Invite users</h4>
+                                <p class="mt-1 text-sm text-gray-600">Start growing your community by inviting fellow dental professionals.</p>
                             </div>
                         </li>
                     </ul>
@@ -87,7 +87,7 @@
 
                 <div class="px-6 py-4 bg-gray-50 text-right rounded-b-lg">
                     <a href="{{ url('/') }}" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-                        Ir a la página principal
+                        Go to home page
                         <svg class="ml-2 -mr-0.5 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                             <path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd" />
                         </svg>
@@ -96,7 +96,7 @@
             </div>
 
             <div class="mt-8 text-center text-sm text-gray-500">
-                &copy; {{ date('Y') }} Comunidad Odontológica. Todos los derechos reservados.
+                &copy; {{ date('Y') }} Dental Community. All rights reserved.
             </div>
         </div>
     </div>

--- a/resources/views/installer/config.blade.php
+++ b/resources/views/installer/config.blade.php
@@ -1,23 +1,23 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Instalador - Configuración - Comunidad Odontológica</title>
+    <title>Installer - Configuration - Dental Community</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
 </head>
 <body class="bg-gray-50">
     <div class="min-h-screen flex flex-col justify-center py-12">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="text-center mb-12">
-                <h1 class="text-4xl font-extrabold text-blue-800 tracking-tight">Comunidad Odontológica</h1>
-                <p class="mt-3 text-xl text-gray-600">Configuración del Instalador</p>
+                <h1 class="text-4xl font-extrabold text-blue-800 tracking-tight">Dental Community</h1>
+                <p class="mt-3 text-xl text-gray-600">Installer Configuration</p>
             </div>
 
             <div class="bg-white shadow rounded-lg">
                 <div class="p-6 border-b border-gray-200">
-                    <h2 class="text-2xl font-semibold text-gray-800">Configuración de la plataforma</h2>
-                    <p class="mt-2 text-gray-600">Por favor, completa todos los campos para configurar tu Comunidad Odontológica.</p>
+                    <h2 class="text-2xl font-semibold text-gray-800">Platform configuration</h2>
+                    <p class="mt-2 text-gray-600">Please fill in all fields to configure your Dental Community.</p>
                 </div>
 
                 @if($errors->any())
@@ -41,60 +41,60 @@
                     @csrf
 
                     <div class="space-y-6">
-                        <h3 class="text-lg font-medium text-gray-900 border-b pb-2">Configuración de la aplicación</h3>
+                        <h3 class="text-lg font-medium text-gray-900 border-b pb-2">Application configuration</h3>
                         
                         <div class="grid grid-cols-1 gap-y-6 gap-x-4 sm:grid-cols-2">
                             <div>
-                                <label for="app_name" class="block text-sm font-medium text-gray-700">Nombre de la aplicación</label>
+                                <label for="app_name" class="block text-sm font-medium text-gray-700">Application name</label>
                                 <div class="mt-1">
                                     <input type="text" name="app_name" id="app_name" value="{{ old('app_name', 'Comunidad Odontológica') }}" class="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md">
                                 </div>
                             </div>
 
                             <div>
-                                <label for="app_url" class="block text-sm font-medium text-gray-700">URL de la aplicación</label>
+                                <label for="app_url" class="block text-sm font-medium text-gray-700">Application URL</label>
                                 <div class="mt-1">
                                     <input type="text" name="app_url" id="app_url" value="{{ old('app_url', Request::root()) }}" class="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md">
                                 </div>
-                                <p class="mt-1 text-xs text-gray-500">URL completa donde está instalada la aplicación</p>
+                                <p class="mt-1 text-xs text-gray-500">Full URL where the application is installed</p>
                             </div>
                         </div>
                     </div>
 
                     <div class="space-y-6">
-                        <h3 class="text-lg font-medium text-gray-900 border-b pb-2">Configuración de la base de datos</h3>
+                        <h3 class="text-lg font-medium text-gray-900 border-b pb-2">Database configuration</h3>
                         
                         <div class="grid grid-cols-1 gap-y-6 gap-x-4 sm:grid-cols-2">
                             <div>
-                                <label for="db_host" class="block text-sm font-medium text-gray-700">Host de la base de datos</label>
+                                <label for="db_host" class="block text-sm font-medium text-gray-700">Database host</label>
                                 <div class="mt-1">
                                     <input type="text" name="db_host" id="db_host" value="{{ old('db_host', '127.0.0.1') }}" class="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md" required>
                                 </div>
                             </div>
 
                             <div>
-                                <label for="db_port" class="block text-sm font-medium text-gray-700">Puerto</label>
+                                <label for="db_port" class="block text-sm font-medium text-gray-700">Port</label>
                                 <div class="mt-1">
                                     <input type="text" name="db_port" id="db_port" value="{{ old('db_port', '3306') }}" class="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md" required>
                                 </div>
                             </div>
 
                             <div>
-                                <label for="db_name" class="block text-sm font-medium text-gray-700">Nombre de la base de datos</label>
+                                <label for="db_name" class="block text-sm font-medium text-gray-700">Database name</label>
                                 <div class="mt-1">
                                     <input type="text" name="db_name" id="db_name" value="{{ old('db_name') }}" class="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md" required>
                                 </div>
                             </div>
 
                             <div>
-                                <label for="db_user" class="block text-sm font-medium text-gray-700">Usuario de la base de datos</label>
+                                <label for="db_user" class="block text-sm font-medium text-gray-700">Database user</label>
                                 <div class="mt-1">
                                     <input type="text" name="db_user" id="db_user" value="{{ old('db_user') }}" class="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md" required>
                                 </div>
                             </div>
 
                             <div>
-                                <label for="db_password" class="block text-sm font-medium text-gray-700">Contraseña de la base de datos</label>
+                                <label for="db_password" class="block text-sm font-medium text-gray-700">Database password</label>
                                 <div class="mt-1">
                                     <input type="password" name="db_password" id="db_password" value="{{ old('db_password') }}" class="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md">
                                 </div>
@@ -103,29 +103,29 @@
                     </div>
 
                     <div class="space-y-6">
-                        <h3 class="text-lg font-medium text-gray-900 border-b pb-2">Configuración del administrador</h3>
+                        <h3 class="text-lg font-medium text-gray-900 border-b pb-2">Administrator configuration</h3>
                         
                         <div class="grid grid-cols-1 gap-y-6 gap-x-4 sm:grid-cols-2">
                             <div>
-                                <label for="admin_name" class="block text-sm font-medium text-gray-700">Nombre de administrador</label>
+                                <label for="admin_name" class="block text-sm font-medium text-gray-700">Administrator name</label>
                                 <div class="mt-1">
                                     <input type="text" name="admin_name" id="admin_name" value="{{ old('admin_name') }}" class="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md" required>
                                 </div>
                             </div>
 
                             <div>
-                                <label for="admin_email" class="block text-sm font-medium text-gray-700">Correo electrónico</label>
+                                <label for="admin_email" class="block text-sm font-medium text-gray-700">Email</label>
                                 <div class="mt-1">
                                     <input type="email" name="admin_email" id="admin_email" value="{{ old('admin_email') }}" class="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md" required>
                                 </div>
                             </div>
 
                             <div>
-                                <label for="admin_password" class="block text-sm font-medium text-gray-700">Contraseña</label>
+                                <label for="admin_password" class="block text-sm font-medium text-gray-700">Password</label>
                                 <div class="mt-1">
                                     <input type="password" name="admin_password" id="admin_password" class="shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md" required>
                                 </div>
-                                <p class="mt-1 text-xs text-gray-500">Mínimo 8 caracteres</p>
+                                <p class="mt-1 text-xs text-gray-500">Minimum 8 characters</p>
                             </div>
                         </div>
                     </div>
@@ -135,11 +135,11 @@
                             <svg class="mr-2 -ml-1 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                                 <path fill-rule="evenodd" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z" clip-rule="evenodd" />
                             </svg>
-                            Atrás
+                            Back
                         </a>
                         
                         <button type="submit" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-                            Instalar
+                            Install
                             <svg class="ml-2 -mr-0.5 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                                 <path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd" />
                             </svg>

--- a/resources/views/installer/welcome.blade.php
+++ b/resources/views/installer/welcome.blade.php
@@ -1,27 +1,27 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Instalador - Comunidad Odontológica</title>
+    <title>Installer - Dental Community</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
 </head>
 <body class="bg-gray-50">
     <div class="min-h-screen flex flex-col justify-center">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
             <div class="text-center mb-12">
-                <h1 class="text-4xl font-extrabold text-blue-800 tracking-tight">Comunidad Odontológica</h1>
-                <p class="mt-3 text-xl text-gray-600">Instalador Automático</p>
+                <h1 class="text-4xl font-extrabold text-blue-800 tracking-tight">Dental Community</h1>
+                <p class="mt-3 text-xl text-gray-600">Automatic Installer</p>
             </div>
 
             <div class="bg-white shadow rounded-lg">
                 <div class="p-6 border-b border-gray-200">
-                    <h2 class="text-2xl font-semibold text-gray-800">Bienvenido al instalador</h2>
-                    <p class="mt-2 text-gray-600">Este asistente te guiará a través de la instalación de la plataforma Comunidad Odontológica.</p>
+                    <h2 class="text-2xl font-semibold text-gray-800">Welcome to the installer</h2>
+                    <p class="mt-2 text-gray-600">This wizard will guide you through the installation of the Dental Community platform.</p>
                 </div>
 
                 <div class="p-6">
-                    <h3 class="text-lg font-medium text-gray-800 mb-4">Requisitos del sistema</h3>
+                    <h3 class="text-lg font-medium text-gray-800 mb-4">System requirements</h3>
                     
                     <ul class="space-y-3">
                         <li class="flex items-center">
@@ -99,7 +99,7 @@
                                     <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
                                 </svg>
                             @endif
-                            <span class="ml-2">Carpeta storage con permisos de escritura</span>
+                            <span class="ml-2">Writable storage directory</span>
                         </li>
                     </ul>
                 </div>
@@ -107,20 +107,20 @@
                 <div class="px-6 py-4 bg-gray-50 rounded-b-lg flex justify-between items-center">
                     <div>
                         @if(!$canContinue)
-                            <p class="text-red-600">Por favor, soluciona los problemas de requisitos antes de continuar.</p>
+                            <p class="text-red-600">Please resolve the requirement issues before continuing.</p>
                         @endif
                     </div>
                     <div>
                         @if($canContinue)
                             <a href="{{ route('installer.config') }}" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-                                Continuar
+                                Continue
                                 <svg class="ml-2 -mr-0.5 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                                     <path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd" />
                                 </svg>
                             </a>
                         @else
                             <button disabled class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gray-400 cursor-not-allowed">
-                                Continuar
+                                Continue
                                 <svg class="ml-2 -mr-0.5 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                                     <path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd" />
                                 </svg>

--- a/resources/views/test.blade.php
+++ b/resources/views/test.blade.php
@@ -2,8 +2,8 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>Prueba de CSS</title>
-    <!-- Usar estilos inline para asegurarnos de que funciona -->
+    <title>CSS Diagnostics</title>
+    <!-- Inline styles to ensure functionality -->
     <style>
         .test-box {
             padding: 1rem;
@@ -17,25 +17,25 @@
     <link href="http://127.0.0.1:8001/build/assets/app-D8IWtaEv.css" rel="stylesheet">
 </head>
 <body>
-    <h1>Diagnóstico de CSS</h1>
+    <h1>CSS Diagnostics</h1>
     
-    <!-- Caja con estilos inline - esto debería verse bien siempre -->
+    <!-- Inline styles box - should always display correctly -->
     <div class="test-box">
-        Este recuadro usa estilos inline y debería verse azul con texto blanco.
+        This box uses inline styles and should appear blue with white text.
     </div>
     
-    <!-- Caja con clases de Tailwind - solo funciona si Tailwind carga -->
+    <!-- Tailwind classes box - works only if Tailwind loads -->
     <div class="p-4 m-4 bg-blue-500 text-white rounded-lg">
-        Si ves este texto en un recuadro azul con texto blanco, Tailwind funciona.
+        If you see this text inside a blue box with white text, Tailwind is working.
     </div>
     
     <hr>
     <div>
-        <h3>Información de depuración:</h3>
-        <p>URL del CSS: <code>{{ asset('build/assets/app-D8IWtaEv.css') }}</code></p>
-        <p>URL de la aplicación: <code>{{ config('app.url') }}</code></p>
-        <p>Ruta absoluta al archivo CSS: <code>{{ public_path('build/assets/app-D8IWtaEv.css') }}</code></p>
-        <p>¿El archivo existe? <code>{{ file_exists(public_path('build/assets/app-D8IWtaEv.css')) ? 'Sí' : 'No' }}</code></p>
+        <h3>Debug information:</h3>
+        <p>CSS URL: <code>{{ asset('build/assets/app-D8IWtaEv.css') }}</code></p>
+        <p>Application URL: <code>{{ config('app.url') }}</code></p>
+        <p>Absolute path to CSS: <code>{{ public_path('build/assets/app-D8IWtaEv.css') }}</code></p>
+        <p>File exists? <code>{{ file_exists(public_path('build/assets/app-D8IWtaEv.css')) ? 'Yes' : 'No' }}</code></p>
     </div>
 </body>
 </html>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -4,10 +4,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="refresh" content="0;url={{ !file_exists(storage_path('installed')) ? '/install' : '/' }}">
-    <title>{{ config('app.name', 'Comunidad Odontológica') }}</title>
+    <title>{{ config('app.name', 'Dental Community') }}</title>
 </head>
 <body>
-    <p>Redireccionando...</p>
+    <p>Redirecting...</p>
     <script>
         window.location.href = "{{ !file_exists(storage_path('installed')) ? '/install' : '/' }}";
     </script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -83,7 +83,7 @@ if (!file_exists(storage_path('installed'))) {
                         'role' => 'admin',
                         'email_verified_at' => now()
                     ]);
-                    echo "<p style='color:green;'>Usuario administrador actualizado: davidkm0393@gmail.com</p>";
+                    echo "<p style='color:green;'>Administrator user updated: davidkm0393@gmail.com</p>";
                 } else {
                     \App\Models\User::create([
                         'name' => 'Administrador',
@@ -99,11 +99,11 @@ if (!file_exists(storage_path('installed'))) {
                 echo "<p><a href='/'>Go to home page</a></p>";
             } catch (\Exception $e) {
                 echo "<p style='color:red;'>Error: " . $e->getMessage() . "</p>";
-                echo "<p>Información de la base de datos:</p>";
+                echo "<p>Database information:</p>";
                 echo "<ul>";
                 echo "<li>Host: " . config('database.connections.mysql.host') . "</li>";
-                echo "<li>Base de datos: " . config('database.connections.mysql.database') . "</li>";
-                echo "<li>Usuario: " . config('database.connections.mysql.username') . "</li>";
+                echo "<li>Database: " . config('database.connections.mysql.database') . "</li>";
+                echo "<li>User: " . config('database.connections.mysql.username') . "</li>";
                 echo "</ul>";
             }
             
@@ -153,11 +153,11 @@ if (!file_exists(storage_path('installed'))) {
                     if (count($users) > 0) {
                         echo "<ul>";
                         foreach ($users as $user) {
-                            echo "<li>" . $user->name . " (" . $user->email . ") - Rol: " . $user->role . "</li>";
+                            echo "<li>" . $user->name . " (" . $user->email . ") - Role: " . $user->role . "</li>";
                         }
                         echo "</ul>";
                     } else {
-                        echo "<p style='color:orange;'>No hay usuarios en la base de datos</p>";
+                        echo "<p style='color:orange;'>No users in the database</p>";
                     }
                 }
             } catch (\Exception $e) {


### PR DESCRIPTION
## Summary
- translate installer pages to English
- update verification email template
- fix web diagnostics route messages
- translate various controller messages
- restore routes and translate output

## Testing
- `composer test` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6840c9b569c08332bcc85a2b48bfaf0b