### PR TITLE
Add API directory test

### DIFF
--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -13,7 +13,9 @@ class ExampleTest extends TestCase
     public function test_the_application_returns_a_successful_response(): void
     {
         $response = $this->get('/');
-
         $response->assertStatus(200);
+
+        $apiResponse = $this->get('/api/directory');
+        $apiResponse->assertStatus(200);
     }
 }


### PR DESCRIPTION
## Summary
- make an additional request to `/api/directory` in ExampleTest

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b12852b88332885d5ab6dcbbf1e6